### PR TITLE
add filter to change get_post_type args

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -49,10 +49,10 @@ if(!class_exists('WP_GeoPostsSettings'))
         	}
 	
 			// Get the default value for the select box
-			$args = array(
+			$args = apply_filters( 'WP_GeoPostsSettings/plugin_settings_page/get_post_types', array(
 				'public'   => true,
 				//'_builtin' => true
-			);
+			));
 			$post_type_bank	= get_post_types($args, 'names', 'and');
 			if(($key = array_search('attachment', $post_type_bank)) !== false)
 			{


### PR DESCRIPTION
I found in using this plugin it would be helpful to filter the $args used on get_post_types for additional parameters. Using a way to control the list on the plugin settings page is useful.
